### PR TITLE
[ShareChat] Introduced the concept of uniform parallelism

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,7 @@ on:
     branches:
       - main
       - release-*
+      - main-sharechat
   pull_request:
 jobs:
   test_ci:

--- a/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
+++ b/docs/layouts/shortcodes/generated/auto_scaler_configuration.html
@@ -224,5 +224,11 @@
             <td>Integer</td>
             <td>The minimum parallelism the autoscaler can use.</td>
         </tr>
+        <tr>
+            <td><h5>job.autoscaler.vertex.uniform-parallelism.enabled</h5></td>
+            <td style="word-wrap: break-word;">false</td>
+            <td>Boolean</td>
+            <td>If true, the autoscaler will enforce the same parallelism for all vertices.</td>
+        </tr>
     </tbody>
 </table>

--- a/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
+++ b/flink-autoscaler/src/main/java/org/apache/flink/autoscaler/config/AutoScalerOptions.java
@@ -132,6 +132,14 @@ public class AutoScalerOptions {
                     .withDescription(
                             "The maximum parallelism the autoscaler can use. Note that this limit will be ignored if it is higher than the max parallelism configured in the Flink config or directly on each operator.");
 
+    public static final ConfigOption<Boolean> VERTEX_UNIFORM_PARALLELISM =
+            autoScalerConfig("vertex.uniform-parallelism.enabled")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withFallbackKeys(oldOperatorConfigKey("vertex.uniform-parallelism.enabled"))
+                    .withDescription(
+                            "If true, the autoscaler will enforce the same parallelism for all vertices.");
+
     public static final ConfigOption<Double> MAX_SCALE_DOWN_FACTOR =
             autoScalerConfig("scale-down.max-factor")
                     .doubleType()


### PR DESCRIPTION
### Context

In Tardis, the autoscale struggled with finding the right balance. The issue is that in the heterogeneous parallelism across all vertices the decisions of autoscaler can be suboptimal. Vertices are not independent, and the current parallelism of "parent" vertex influences how much traffic receives a "child" vertex, hence impacts the decision when we decide new parallelims of the "child" vertex. Basically - the relative parallelism of vertices can change after scale event, and in the new - changed - situation the decision about the optimal scaling can be very different.

How it looks like in practice is tons of "bouncing": autoscaler scales down, then quickly realizes it needs to upscale back. And this process never ends, no matter how hard we try to tune parameters.

<img width="896" alt="image" src="https://github.com/user-attachments/assets/05d32637-cc96-4d60-8021-49396e297234">

### This PR

Introduces the concept of "flat parallelism". To reduce the "cognitive load" on autoscaler and prevent the situation when relative parallelism changes over time, we can simply maintain the same parallelism across all vertices. Pretty much like we do now in Tardis.

With this setting, Tardis job autoscales perfectly, maintaining small lag without "bouncing" back situations.

<img width="895" alt="image" src="https://github.com/user-attachments/assets/ca2f77e8-7ad4-4009-8fdd-3be5971dd8f6">

<img width="893" alt="image" src="https://github.com/user-attachments/assets/f9060ee1-0503-47b0-ac89-8babfc472862">

