### PR TITLE
[ShareChat] Tolerate legacy ClusterHealthInfo fields on upgrade from <1.15

### DIFF
--- a/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/health/ClusterHealthInfo.java
+++ b/flink-kubernetes-operator/src/main/java/org/apache/flink/kubernetes/operator/health/ClusterHealthInfo.java
@@ -20,6 +20,7 @@ package org.apache.flink.kubernetes.operator.health;
 import org.apache.flink.annotation.Experimental;
 import org.apache.flink.kubernetes.operator.observer.ClusterHealthResult;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.AllArgsConstructor;
@@ -31,6 +32,7 @@ import java.time.Clock;
 @Experimental
 @Data
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ClusterHealthInfo {
     /** Millisecond timestamp of the last observed health information. */
     private long timeStamp;


### PR DESCRIPTION
## Summary

Adds `@JsonIgnoreProperties(ignoreUnknown = true)` to `ClusterHealthInfo` so the 1.15 operator binary can deserialize `ClusterHealthInfo` JSON written by older operator versions (e.g. 1.10) that contain the legacy `healthy` field.

## Problem

Upstream commit [FLINK-37769](https://issues.apache.org/jira/browse/FLINK-37769) *"Include cause in event when restarting unhealthy job"* renamed the `ClusterHealthInfo.healthy` (`boolean`) field to `healthResult` (`ClusterHealthResult`). The rename is non-backward-compatible: Jackson's default strict mode rejects the legacy field on read.

Every existing `FlinkDeployment` reconciled by a pre-1.15 operator has a persisted `status.clusterInfo.ClusterHealthInfo` JSON containing `"healthy": ...`. When a 1.15 operator picks up reconciliation, the read in `ClusterHealthEvaluator.getLastValidClusterHealthInfo` throws:

```
com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException:
  Unrecognized field "healthy" (class ClusterHealthInfo), not marked as ignorable
  (6 known properties: numRestartsEvaluationTimeStamp, timeStamp, healthResult,
   numRestarts, numCompletedCheckpoints, numCompletedCheckpointsIncreasedTimeStamp)
```

This call sits on the **main reconcile path** (`ApplicationReconciler.reconcileOtherChanges` → `AbstractFlinkResourceReconciler.reconcile` → `FlinkDeploymentController.reconcile`), so the exception aborts reconciliation and the operator enters a retry loop. The job's data plane (JM/TMs) keeps running because nothing actively removes it, but the operator can't take any corrective action — savepoints, upgrades, scaling, restart-on-failure are all blocked.

Side effects observed during testing:
- Operator log floods every ~12 s with the stack trace
- Reconciliation retry counter climbs (saw `Attempt count: 11`)
- Autoscaler can't progress past the initial sample window because the upstream reconcile fails

## Root cause

`ClusterHealthInfo.deserialize` uses a default `ObjectMapper` with `FAIL_ON_UNKNOWN_PROPERTIES = true` (Jackson default). The class also has no `@JsonIgnoreProperties` annotation, so any field the new schema doesn't recognise becomes a hard failure.

## Fix

Single-line additive change: class-level `@JsonIgnoreProperties(ignoreUnknown = true)`.

```diff
 @Experimental
 @Data
 @AllArgsConstructor
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class ClusterHealthInfo {
```

After the patch, the 1.15 binary reads the legacy JSON, silently ignores `healthy`, populates the other fields, and on the next reconcile writes a fresh `ClusterHealthInfo` in the new shape (`healthResult: {healthy, error}`). **No manual cleanup of existing `FlinkDeployment` status is required during the upgrade.**

## Validation

Tested against the [tardis](https://github.com/ShareChat/tardis) repo's `SC_SQL_LIFETIME_FEATURES` job in the `test-apache-flink` namespace on `sc-p-ds-generic-services-01`. Test mirrored a real prod upgrade path rather than a fresh install — side-namespace fresh-install tests don't exercise stored-state migration and would miss this class of bug.

### Reproducing the bug pre-patch

1. Installed operator `sharechat-1.10.0-rc1` in `test-apache-flink` via Helm (upstream 1.10.0 chart, ShareChat-built image).
2. Deployed `SC_SQL_LIFETIME_FEATURES` job. Let it run for ~24 h so it accumulated meaningful state: ~525 MB RocksDB state, 1466 completed checkpoints, periodic `ClusterHealthInfo` writes containing `"healthy": true`.
3. Upgraded operator to `sharechat-1.15.0-rc2` via `helm upgrade --atomic --skip-crds` against the 1.15.0-rc2 chart from Apache dist-dev.
4. Operator started successfully but immediately entered reconcile-retry loop with the `UnrecognizedPropertyException` shown above. Confirmed via stack trace that the call originated from the main reconcile path.

### Confirming the diagnosis

To verify the bug is purely a read-side issue (not a deeper persistence problem):

1. Scaled operator deployment to 0 replicas.
2. Patched the `FlinkDeployment` status to replace the legacy `healthy` field with a valid 1.15-shape `healthResult: {healthy: true, error: null}` payload.
3. Scaled operator back up.

**Result:** operator log went from continuous exceptions to clean reconcile cycles (`Resource fully reconciled, nothing to do...`), autoscaler resumed metric collection, and the operator wrote its own fresh `ClusterHealthInfo` with current values (`numCompletedCheckpoints` caught up from the frozen 1438 to the live 1492). This proved the operator binary itself is functionally correct — only the read of legacy data fails.

### Functional validation of the 1.15 binary (against manually-patched state)

Verified the four operator-driven scenarios that Tardis relies on in prod:

| # | Scenario | Result |
|---|----------|--------|
| 1 | JobManager pod failure (`kubectl delete pod`) | ✅ ~22 s recovery, TaskManagers preserved, no state loss, FlinkDeployment back to `RUNNING/STABLE` |
| 2 | TaskManager pod failure (`kubectl delete pod`) | ✅ Job failover, restored from latest checkpoint, checkpoint IDs continued 1492 → 1506 → 1507 |
| 3 | Savepoint-based upgrade (`spec.restartNonce` bump, `upgradeMode: savepoint`) | ✅ ~2m16s total; savepoint written to GCS at `gs://tardis-sc-feed-features-jobs/savepoints/.../savepoint-9012de-c4ccfc8610be`; new JM/TMs restored from it; `upgradeSavepointPath` recorded in status |
| 4 | Stateless upgrade (`spec.restartNonce` bump, `upgradeMode: stateless`) | ✅ ~1m7s total; no savepoint written; HA metadata wiped; new `jobId` assigned; checkpoints restarted from ID 1 |

### Why the source patch is the only viable fix

The manual `kubectl patch` workaround only persisted while the operator was scaled to 0 — once the operator came back up with cached state, it overwrote the patches within a single reconcile cycle. For prod rollout this is operationally infeasible: every existing `FlinkDeployment` in the `apache-flink` namespace would need this manual cleanup at upgrade time, racing against the operator's own writes.

The source patch makes the 1.15 binary tolerant of the legacy field on read, so the upgrade is transparent — the binary reads the old data, ignores the unknown field, and writes back the new shape on next reconcile.

## Test plan

After this lands and a new ShareChat 1.15 image is published as `sharechat-1.15.0-rc3`:

- [ ] Roll back operator in `test-apache-flink` to `sharechat-1.10.0-rc1`
- [ ] Wait until 1.10 has persisted `ClusterHealthInfo` with `"healthy": true`
- [ ] `helm upgrade --skip-crds` to `sharechat-1.15.0-rc3`
- [ ] Operator log clean — no `UnrecognizedPropertyException`
- [ ] `status.clusterInfo.ClusterHealthInfo` gets rewritten to the new `healthResult: {...}` shape on first reconcile (no manual patch required)
- [ ] FlinkDeployment stays `RUNNING/STABLE` throughout

## Related upstream

- [FLINK-37769](https://issues.apache.org/jira/browse/FLINK-37769) — the upstream commit that introduced the rename. No upgrade-compatibility mitigation in upstream as of `release-1.15.0-rc2`. Worth filing a JIRA upstream for this — the same `@JsonIgnoreProperties` change would help anyone upgrading from <1.15.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Enhanced cluster health information processing to gracefully handle JSON payloads with additional or unexpected fields, improving system stability and resilience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ShareChat/flink-kubernetes-operator/pull/8)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->